### PR TITLE
Updated to work with NIST API 2.0

### DIFF
--- a/modules/nist_search.py
+++ b/modules/nist_search.py
@@ -85,10 +85,10 @@ def searchCVE(keyword: str, log, apiKey=None) -> list[Vulnerability]:
             break
 
     Vulnerabilities = []
-    if not "vulnerabilities" in data:
+    if not data or not "vulnerabilities" in data:
         return []
 
-    for vuln in data["vulnerabilities"]:
+    for vuln in data.get("vulnerabilities", []):
         title = keyword
         (
             CVE_ID,

--- a/modules/nist_search.py
+++ b/modules/nist_search.py
@@ -74,13 +74,15 @@ def FindVars(vuln: dict) -> tuple:
 
 
 def searchCVE(keyword: str, log, apiKey=None) -> list[Vulnerability]:
-    url = "https://services.nvd.nist.gov/rest/json/cves/1.0?"
+    url = "https://services.nvd.nist.gov/rest/json/cves/2.0?"
     if apiKey:
         sleep_time = 0.1
-        paramaters = {"keyword": keyword, "apiKey": apiKey}
+        parameters = {"keyword": keyword}
+        headers = {"apiKey": apiKey}
     else:
         sleep_time = 8
-        paramaters = {"keyword": keyword}
+        parameters = {"keyword": keyword}
+        headers = {}
 
     if keyword in cache:
         return cache[keyword]
@@ -88,7 +90,7 @@ def searchCVE(keyword: str, log, apiKey=None) -> list[Vulnerability]:
     for tries in range(3):
         try:
             sleep(sleep_time)
-            request = get(url, params=paramaters)
+            request = get(url, params=parameters, headers=headers)
             data = request.json()
         except Exception as e:
             if request.status_code == 403:


### PR DESCRIPTION
NIST retired the 1.0 APIs that this project relied upon on Dec 18, 2023. This is causing the nist_search module to receive a 404 error for every keyword search and return no data. There are currently 2 issues #46 and #47 that this PR would fix, both the same root cause.

See the timeline of the API retirement [here](https://nvd.nist.gov/general/news/change-timeline)

The endpoint was changed from 1.0 to 2.0, the keyword parameter is now "keywordSearch" instead of "keyword", and the 2.0 API requires the API key in a header instead of a get parameter.

The response schema has also changed, so I had to update FindVulns to account for that as well.